### PR TITLE
Minor Optimizations

### DIFF
--- a/dieke/__init__.py
+++ b/dieke/__init__.py
@@ -542,12 +542,12 @@ def makeFullFreeIonOperators(nf, LSJlevels, fi_mat):
     for i in range(len(LSJlevels)):
         istart = multiplet_start[i]
         isize = multiplet_size[i]
-        istop = istart+isize
+        # istop = istart+isize
         for j in range(len(LSJlevels)):
             if isize != multiplet_size[j]:
                 continue
             jstart = multiplet_start[j]
-            jstop = jstart+isize
+            # jstop = jstart+isize
             for key in full_fi_mat.keys():
                 for d in range(isize):
                     full_fi_mat[key][istart + d, jstart + d] = fi_mat[key][i, j]

--- a/dieke/__init__.py
+++ b/dieke/__init__.py
@@ -774,7 +774,7 @@ def read_crosswhite(nf):
         # fill in the other triangle
     for key in fi_mat.keys():
         olddiag = fi_mat[key].diagonal()
-        fi_mat[key] = fi_mat[key]+np.transpose(fi_mat[key])
+        fi_mat[key] = (fi_mat[key]+fi_mat[key].T).tolil()
         fi_mat[key].setdiag(olddiag)
     # Why 1000 indeed ...
     fi_mat['ALPHA'] = 1000*fi_mat['.01ALPH']

--- a/dieke/__init__.py
+++ b/dieke/__init__.py
@@ -549,8 +549,8 @@ def makeFullFreeIonOperators(nf, LSJlevels, fi_mat):
             jstart = multiplet_start[j]
             jstop = jstart+isize
             for key in full_fi_mat.keys():
-                full_fi_mat[key][istart:istop, jstart:jstop] = \
-                                np.eye(isize)*fi_mat[key][i, j]
+                for d in range(isize):
+                    full_fi_mat[key][istart + d, jstart + d] = fi_mat[key][i, j]
     return (LSJmJstates, full_fi_mat)
 
 


### PR DESCRIPTION
When constructing `full_fi_mat` under the `makeFullFreeIonOperators(...)` class method, per-diagonal element writes are more efficient than 2D slice assignments for `lil_matrix` objects. This is because `np.eye(n) * val` is a dense temporary matrix that LIL has to process and assign line-by-line to maintain its sparse structure. Iterating only on the diagonal elements cuts the matrix building from O(n^2) to O(n).

When constructing `Ckq`, specifically `cmatrix`, under the `makeCkq(...)` method, pruning the cases where `singlyreducedUk` is zero first reduces some calls. This is introduced as the iterable `nonzero`. Furthermore, Wigner-3j enforces `−m + q + m′ = 0 ⇒ -J' + ij = -J + ii - q`, so there is only one value of `ij` that is non-zero given `ii`, and we can bypass the for loop involving `ij` entirely. The time complexity here improves from O(`isize*jsize`) down to just O(`isize`), and we avoid many `wignerlookup.w3j(...)` calls.

I've verified that the matrices produced by the pre-commit and post-commit scripts are the same.